### PR TITLE
fix: ESLint 경고 및 미사용 변수 제거

### DIFF
--- a/src/components/match-analysis/telemetry/LogMapCanvas.tsx
+++ b/src/components/match-analysis/telemetry/LogMapCanvas.tsx
@@ -363,7 +363,6 @@ export default function LogMapCanvas({
     isDragging.current = true;
     setDragging(true);
     lastPos.current = getPos(e.clientX, e.clientY);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const handleMouseMove = useCallback(
@@ -453,7 +452,6 @@ export default function LogMapCanvas({
 
       setTooltip(found);
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [killData, groggyData, damageData, movementData, mapSize, applyZoom]
   );
 

--- a/src/components/match-analysis/telemetry/TelemetryMapView.tsx
+++ b/src/components/match-analysis/telemetry/TelemetryMapView.tsx
@@ -174,12 +174,6 @@ export default function TelemetryMapView({
 
   const isLoading = movLoading || killLoading || groggyLoading || dmgLoading;
 
-  // 오프셋 범위 제한 (맵이 항상 캔버스를 채우도록)
-  const clamp = useCallback((ox: number, oy: number, z: number) => ({
-    x: Math.min(0, Math.max(CANVAS_SIZE * (1 - z), ox)),
-    y: Math.min(0, Math.max(CANVAS_SIZE * (1 - z), oy)),
-  }), []);
-
   const applyZoom = useCallback(
     (newZoom: number, newOffset: { x: number; y: number }) => {
       zoomRef.current = newZoom;
@@ -394,7 +388,6 @@ export default function TelemetryMapView({
     isDragging.current = true;
     setDragging(true);
     lastPos.current = getPos(e.clientX, e.clientY);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const handleMouseMove = useCallback((e: React.MouseEvent<HTMLCanvasElement>) => {
@@ -483,7 +476,6 @@ export default function TelemetryMapView({
     }
 
     setTooltip(found);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [layers, killData, groggyData, damageData, movementData, mapSize, applyZoom]);
 
   const handleMouseUp = useCallback(() => {


### PR DESCRIPTION
- TelemetryMapView: 미사용 clamp 함수 제거
- TelemetryMapView, LogMapCanvas: 불필요한 eslint-disable 주석 제거

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk cleanup: removes unused code and unnecessary ESLint suppression comments without changing runtime logic.
> 
> **Overview**
> Cleans up telemetry map components by removing an unused `clamp` helper from `TelemetryMapView` and deleting unnecessary `eslint-disable-next-line react-hooks/exhaustive-deps` comments in `TelemetryMapView` and `LogMapCanvas`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b86893deb7c53f5bac5cde9e38a2d4ed739fa717. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->